### PR TITLE
[DISCUSS] Use plotly for interactive plot

### DIFF
--- a/install.R
+++ b/install.R
@@ -9,3 +9,5 @@ install.packages("lubridate")
 install.packages("tidyr")
 install.packages("magrittr")
 install.packages("bit64")
+install.packages("plotly")
+

--- a/server.R
+++ b/server.R
@@ -8,6 +8,7 @@ library(stringr)
 library(lubridate)
 library(tidyr)
 library(magrittr)
+library(plotly)
 options(shiny.sanitize.errors = FALSE)
 
 # load population data: How many people live in each country?
@@ -301,7 +302,7 @@ shinyServer(function(input, output, session) {
 	
 	
 	# the plot
-	output$res <- renderUI({
+	output$res <- renderPlotly({
 		
 	  print("PLOT:")
 		print(str(dat_selection()))
@@ -315,7 +316,8 @@ shinyServer(function(input, output, session) {
 		p1 <- ggplot(dat_selection(), aes_string(x="day_since_start", y=input$target, color="country")) + 
 			geom_point() + 
 			geom_line() + 
-			geom_label_repel(aes(label = country_label), nudge_x = 1, na.rm = TRUE) + scale_color_discrete(guide = FALSE) +
+			#geom_label_repel(aes(label = country_label), nudge_x = 1, na.rm = TRUE) + 
+			scale_color_discrete(guide = FALSE) +
 			theme_bw() + 
 			xlab(paste0("Days since ", input$start_cumsum, "th case")) + 
 			ylab(y_label) +
@@ -325,10 +327,10 @@ shinyServer(function(input, output, session) {
 		  p1 <- p1 + coord_trans(y = "log10")
 		}
 		if (input$target == "cum_cases") {
-			p1 <- p1 + scale_y_continuous(breaks=c(100, 200, 500, 1000, 2000, 5000, 10000, 20000))
+		  p1 <- p1 + scale_y_continuous(breaks=c(100, 200, 500, 1000, 2000, 5000, 10000, 20000))
 		}
 		if (input$target == "cum_cases_per_100000") {
-			p1 <- p1 + scale_y_continuous()
+		  p1 <- p1 + scale_y_continuous()
 		}
 		
 		if (input$showReferenceLine == TRUE) {
@@ -337,9 +339,7 @@ shinyServer(function(input, output, session) {
 		    annotate(label=paste0(input$percGrowth, "% growth rate"), x=max_day_since_start(), y=growth(max_day_since_start()+1, percGrowth=input$percGrowth, intercept=input$offset), geom="text", hjust=1)
 		}
 				
-		return(tagList(
-		  renderPlot(p1, res=100, height=600, width="auto")
-		))
+		return(p1)
 	
 	})
 	

--- a/ui.R
+++ b/ui.R
@@ -76,7 +76,7 @@ shinyUI(fluidPage(theme = shinytheme("spacelab"),
 		),
 			
 		column(8,
-			htmlOutput("res"),
+			plotlyOutput("res", height="600px"),
 			downloadButton("DownloadFig", "Download Plot")
 		)			
 	),


### PR DESCRIPTION
These makes the plot more interactive, e.g. information when hovering at a point, comparing values, zooming. But there are currently some drawbacks:
- The `geom_label_repel` cannot be used for positioning the labels on the lines directly.
- I haven't managed to delete or move the legend on the right. However, that should be solvable.
- At the beginning when loading an Error about some options appear.

Try it out under https://mybinder.org/v2/gh/zuphilip/corona/plotly?urlpath=shiny

![corona-interactive](https://user-images.githubusercontent.com/5199995/76688859-1b8ede80-6631-11ea-99a1-ff30d71b67e3.jpg)
